### PR TITLE
Deploy

### DIFF
--- a/ansible/roles/django/tasks/main.yml
+++ b/ansible/roles/django/tasks/main.yml
@@ -37,6 +37,11 @@
     db_url: "{{ db_host.ec2_engine }}://{{ db_host.ec2_master_username }}:{{ db_password }}@{{ db_host.ec2__address }}:{{ db_host.ec2__port }}/{{ db_host.ec2_DBName }}"
 
 
+- name: Set Host Password
+  set_fact: 
+    host_password: "{{ email_password }}"
+
+
 - name: Create environmental variable script
   sudo: yes
   template: src=moddropsecrets.conf dest={{ django_home }}/secretsremote.conf

--- a/ansible/roles/django/tasks/main.yml
+++ b/ansible/roles/django/tasks/main.yml
@@ -36,6 +36,12 @@
   set_fact: 
     db_url: "{{ db_host.ec2_engine }}://{{ db_host.ec2_master_username }}:{{ db_password }}@{{ db_host.ec2__address }}:{{ db_host.ec2__port }}/{{ db_host.ec2_DBName }}"
 
+
+- name: Create environmental variable script
+  sudo: yes
+  template: src=moddropsecrets.conf dest={{ django_home }}/secretsremote.conf
+
+
 - name: Run Migrations
   environment:
     DJANGO_CONFIGURATION: Prod

--- a/ansible/roles/django/templates/moddropsecrets.conf
+++ b/ansible/roles/django/templates/moddropsecrets.conf
@@ -1,0 +1,5 @@
+export DJANGO_SETTINGS_MODULE=mod_drops.settings
+export DJANGO_CONFIGURATION=Prod
+export DATABASE_URL={{ db_url }}
+export HOST_USER=moddrops@gmail.com
+export HOST_PASSWORD={{ host_password }}


### PR DESCRIPTION
Script file pushed up by ansible so that a team member can use the manage.py from the remote. An operator just needs to source the script (moddropsecrets.conf) before running manage.py
